### PR TITLE
Compatibility adjustments.

### DIFF
--- a/lib/changeNIDMtoTabDat.m
+++ b/lib/changeNIDMtoTabDat.m
@@ -450,7 +450,7 @@ function NTabDat = changeNIDMtoTabDat(graph, typemap, context, ids, exObj)
         
         %Get number of peaks to display
         if isfield(peakDefCriteria{1}, context('nidm_maxNumberOfPeaksPerCluster'))
-            numOfPeaks = get_value(peakDefCriteria{1}.nidm_maxNumberOfPeaksPerCluster);
+            numOfPeaks = str2double(get_value(peakDefCriteria{1}.nidm_maxNumberOfPeaksPerCluster));
         else
             numOfPeaks = 3;
         end 

--- a/lib/getBase64.m
+++ b/lib/getBase64.m
@@ -15,7 +15,11 @@ function base64string = getBase64(imagePath)
     fclose(fid);
     
     %Encode the image and return the string.
-    encoder = org.apache.commons.codec.binary.Base64;
-    base64string = char(encoder.encode(bytes))';
+    if ~exist('OCTAVE_VERSION','builtin')
+        encoder = org.apache.commons.codec.binary.Base64;
+        base64string = char(encoder.encode(bytes))';
+    else
+        base64string = base64_encode(uint8(bytes));
+    end
 
 end

--- a/nidm_results_display.m
+++ b/nidm_results_display.m
@@ -22,8 +22,8 @@ function webID = nidm_results_display(nidmfilepath, conInstruct, outdir)
     end
     
     %If it is zipped unzip it.
-    if contains(nidmfilepath, '.zip')
-        [path, filename] = fileparts(nidmfilepath);
+    [path, filename, ext] = fileparts(nidmfilepath);
+    if strncmp(ext, '.zip', 4)
         unzip(nidmfilepath, fullfile(path, filename));
         nidmfilepath = fullfile(path, filename);
     end

--- a/nidm_results_display.m
+++ b/nidm_results_display.m
@@ -12,7 +12,12 @@
 %==========================================================================
 
 function webID = nidm_results_display(nidmfilepath, conInstruct, outdir)
- 
+
+    %Add path to required methods
+    if ~isdeployed && exist('changeNIDMtoSPM', 'file') ~= 2
+        addpath(fullfile(fileparts(mfilename('fullpath')), 'lib'));
+    end
+
     spm_progress_bar('Init',10,'Unpacking NIDM-Results','Current stage');
      
     %Check input
@@ -49,11 +54,6 @@ function webID = nidm_results_display(nidmfilepath, conInstruct, outdir)
     end
     
     context = load_json_context(jsondoc);
-
-    %Add path to required methods
-    if exist('changeNIDMtoSPM', 'file') ~= 2
-        addpath(fullfile(fileparts(mfilename('fullpath')), 'lib'));
-    end
     
     % Deal with sub-graphs (bundle)
     if ~iscell(jsondoc)

--- a/spm_results_export.m
+++ b/spm_results_export.m
@@ -231,7 +231,9 @@ fprintf(fid,'%c',get(tpl,'OUT'));
 fclose(fid);
 %==========================================================================
 %-Delete temporary files
-
+if exist('OCTAVE_VERSION','builtin')
+    confirm_recursive_rmdir(false,'local');
+end
 rmdir(outdir, 's');
 
 %-Display webpage
@@ -240,10 +242,9 @@ rmdir(outdir, 's');
 %cmdline is stored we are running code without SPM actually open (i.e. for 
 %tests). We display only if we are not in commandline mode.
 try
-    defaults = spm('Defaults', 'FMRI');
-    display = ~defaults.cmdline;
+    display = ~spm_get_defaults('cmdline');
 catch
-    display = 1;
+    display = true;
 end 
 
 %Display if not in commandline mode.

--- a/spm_results_export.m
+++ b/spm_results_export.m
@@ -96,7 +96,7 @@ if exist(fHTML, 'file') == 2
         1,'bd',{'Overwrite', 'Do not overwrite'},[1,2],2);
     if isempty(button) || button == 2
         webID = '0';
-        return;true;
+        return;
     end
 end
 

--- a/spm_results_export.m
+++ b/spm_results_export.m
@@ -91,22 +91,12 @@ end
 %If fHTML already exists, ask if it should be overWritten.
 
 if exist(fHTML, 'file') == 2
-    if(multipleExcursions)
-        button = questdlg(['The output file, index', num2str(exNo), '.html, already exists. Would you like this file to be overwritten?'], 'Warning', 'Overwrite', 'Do not overwrite', 'Do not overwrite');      
-    else
-        button = questdlg(['The output file, index.html, already exists. Would you like this file to be overwritten?'], 'Warning', 'Overwrite', 'Do not overwrite', 'Do not overwrite');      
-    end
-    switch button
-        case 'Overwrite'
-            overWrite = true;
-        case 'Do not overwrite'
-            overWrite = false;
-        case ''
-            overWrite = false;
-    end
-    if(~overWrite)
+    button = spm_input(['The output file, ', spm_file(fHTML,'filename'), ...
+        ', already exists. Would you like this file to be overwritten?'],...
+        1,'bd',{'Overwrite', 'Do not overwrite'},[1,2],2);
+    if isempty(button) || button == 2
         webID = '0';
-        return
+        return;true;
     end
 end
 
@@ -236,20 +226,10 @@ if exist('OCTAVE_VERSION','builtin')
 end
 rmdir(outdir, 's');
 
-%-Display webpage
+%-Display webpage (if not in commandline mode)
 %==========================================================================
-%Check if we are running from the commandline. If no information about
-%cmdline is stored we are running code without SPM actually open (i.e. for 
-%tests). We display only if we are not in commandline mode.
-try
-    display = ~spm_get_defaults('cmdline');
-catch
-    display = true;
-end 
-
-%Display if not in commandline mode.
-if display
-    if(multipleExcursions && exNo >1)
+if ~spm('CmdLine')
+    if (multipleExcursions && exNo >1)
         [~, webID] = web(fHTML, '-new');
     else
         [~, webID] = web(fHTML);

--- a/tbx_cfg_NIDM_display.m
+++ b/tbx_cfg_NIDM_display.m
@@ -7,9 +7,11 @@
 function nidmdisplay = tbx_cfg_NIDM_display()
     
     %Add the path to the toolbox directory.
-    toolboxDir = spm_str_manip(mfilename('fullpath'), 'h');
-    addpath(toolboxDir);
-    addpath(fullfile(toolboxDir, 'test'));
+    toolboxDir = spm_file(mfilename('fullpath'), 'fpath');
+    if ~isdeployed
+        addpath(toolboxDir);
+        addpath(fullfile(toolboxDir, 'test'));
+    end
     
     %Excursion sets specified numerically.
     exSet_num          = cfg_entry;


### PR DESCRIPTION
Small changes for Matlab/Octave compatibility.

I also had to change spm_file_template.m:
```
--- spm_file_template.m (revision 7311)
+++ spm_file_template.m (working copy)
@@ -28,11 +28,11 @@
 end
 
 properties (SetAccess='private', GetAccess='private')
-    filekeys;
-    filenames;
+    filekeys = {};
+    filenames = {};
     
-    varkeys;
-    varvals;
+    varkeys = {};
+    varvals = {};
 end
 
 %-Constructor
```

There is now a bug report filled on the Octave bug tracker for the underlying compatibility issue.

The last remaining issue is the `web` function. It might not be an issue for the tests if they run without display?